### PR TITLE
Allow forwarding of command-line arguments to the underlying code

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ Thanks to Chris Done's
 [`foreign-store`](https://hackage.haskell.org/package/foreign-store) 
 library for enabling this.
 
+Passing command-line arguments
+------------------------------
+
+To use Halive with haskell code that is expecting command-line arguments,
+separate the arguments to Halive and the argumetns to the app with a `--`
+such as:
+
+`halive <path/to/mymain.hs> <extra-include-dirs> -- <args-to-myapp>`
+
 Notes
 -----
 

--- a/exec/main.hs
+++ b/exec/main.hs
@@ -2,11 +2,16 @@ import Halive
 import Banner
 import System.Environment
 
+separateArgs args = do
+  let (haliveArgs, targetArgs) = break (=="--") args
+  in  (haliveArgs, drop 1 targetArgs)
+
 main :: IO ()
 main = do
-    args <- getArgs
+    (args, targetArgs) <- separateArgs <$> getArgs
+    print targetArgs
     case args of
-        [] -> putStrLn "Usage: halive <main.hs> <include dir>"
+        [] -> putStrLn "Usage: halive <main.hs> <include dir> [-- <args to myapp>]"
         (mainName:includeDirs) -> do
             putStrLn banner
-            recompiler mainName includeDirs
+            withArgs targetArgs $ recompiler mainName includeDirs


### PR DESCRIPTION
My specific use-case is using halive with hspec. Currently if I try to do so, I get an error: `unexpected argument: test/Main.hs` because hspec simply grabs the command-line arguments and ends up with whatever I've passed to halive.

This pull request allows me to pass separate command-line arguments to hspec by doing: `halive test/Main.hs src -- args to hspec`.

Note that if there is no `--` the underlying app will get `[]` when calling getArgs.