### PR TITLE
 (Optionally) copy '-package-id' args from 'stack'

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ halive demo/Main.hs
 ```
 Changing values in `Main.hs` or `Green.hs` and saving should live-update the program.
 
+* Note: if you get an error about an ``Ambiguous module name``, you can use this
+  command line instead:
+
+  ``HALIVE_STACK_COMPONENT=halive:test:demo halive demo/Main.hs``
+
+  It will be slower.
+
 Keeping values alive
 --------------------
 

--- a/demo/SetupGLFW.hs
+++ b/demo/SetupGLFW.hs
@@ -1,12 +1,18 @@
+{-# LANGUAGE LambdaCase #-}
 module SetupGLFW where
 
 import qualified Graphics.UI.GLFW as GLFW
 
 import Control.Monad
+import Data.Bool
+import System.Exit
+import System.IO
 
 setupGLFW :: String -> Int -> Int -> IO GLFW.Window
 setupGLFW windowName desiredW desiredH = do
-    _ <- GLFW.init
+
+    GLFW.setErrorCallback (Just (const (hPutStrLn stderr)))
+    GLFW.init >>= bool (bail initFailMsg) (return ())
 
     GLFW.windowHint $ GLFW.WindowHint'ClientAPI GLFW.ClientAPI'OpenGL
     GLFW.windowHint $ GLFW.WindowHint'OpenGLForwardCompat True
@@ -14,10 +20,15 @@ setupGLFW windowName desiredW desiredH = do
     GLFW.windowHint $ GLFW.WindowHint'ContextVersionMajor 4
     GLFW.windowHint $ GLFW.WindowHint'ContextVersionMinor 1
     GLFW.windowHint $ GLFW.WindowHint'sRGBCapable True
-    
-    Just win <- GLFW.createWindow desiredW desiredH windowName Nothing Nothing
-    
-    GLFW.makeContextCurrent (Just win)
 
-    GLFW.swapInterval 1
-    return win
+    GLFW.createWindow desiredW desiredH windowName Nothing Nothing >>= \case
+        Nothing -> bail cwFailMsg
+        Just win -> do
+            GLFW.makeContextCurrent (Just win)
+            GLFW.swapInterval 1
+            return win
+
+  where
+    initFailMsg = "Error: GLFW init() failed; perhaps $DISPLAY is not set."
+    cwFailMsg = "Error: GLFW createWindow() failed; probably your GPU is too old."
+    bail = hPutStrLn stderr >=> const exitFailure >=> undefined

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: nightly-2015-12-03
+resolver: lts-4.0


### PR DESCRIPTION
If the environment variable 'HALIVE_STACK_COMPONENT' is set, its value
will be passed to 'stack ghci' as the component to use.  The command
line used to launch 'ghci' is extracted from 'stack' log output, and the
'-package-id=<...>' arguments used to configure the 'DynFlags' passed to
'runGhc'.

This is necessary when the stack package dbs contain multiple packages
that provide the same module.  Without it, 'runGhc' will not be able to
know which package should be used to provide the module, producing an
error such as this:

  demo/Shader.hs:3:8:
      Ambiguous module name ‘Graphics.GL’:
        it was found in multiple packages:
        gl-0.7.7@gl_8feL1KNX30C7cRvC5KMerD OpenGLRaw-3.0.0.0@OpenG_2ifknuoKtb4Jnk98tmsl6Y

This is very slow, since it has to compile the project with 'ghci' just
to get the arguments -- only to be used to compile it again!  But it
does make 'halive' work in situations where, without it, there would
only be failure.

(A proper solution would involve modifying 'stack' to provide this
information more efficiently.)