### PR TITLE
Ignores emacs flycheck/flymake and before-save files

### DIFF
--- a/src/Halive/FileListener.hs
+++ b/src/Halive/FileListener.hs
@@ -101,8 +101,7 @@ forkDirectoryListenerThread watchDirectory fileTypes eventChan = do
     stopMVar <- newEmptyMVar
     _ <- forkIO . withManagerConf watchConfig $ \manager -> do
 
-        stop <- watchTree manager watchDirectory predicate $ \e -> do
-            print e
+        stop <- watchTree manager watchDirectory predicate $ \e ->
             writeTChanIO eventChan (Left e)
         () <- takeMVar stopMVar
         stop
@@ -127,7 +126,6 @@ forkFileListenerThread fileName shouldReadFile eventChan ignoreEventsNear = do
         let watchDirectory = takeDirectory fileName
 
         stop <- watchTree manager watchDirectory predicate $ \e -> do
-            print e
             mTimeToIgnore <- atomically $ readTVar ignoreEventsNear
             let timeOfEvent = eventTime e
                 shouldIgnore = case mTimeToIgnore of


### PR DESCRIPTION
This fixes an issue where halive needlessly works too hard recompiling before a file is actually saved (at least when used w/ emacs). vim + atom files can easily be added. Also - forgive me because my editor automatically updates imports to my work's conventions. I'll fix it up if need be.