### PR TITLE
Fixes #11 - Added support for custom file types

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -25,7 +25,7 @@ TODO:
 
         [ ] Watch all included path trees rather than the current directory.
 
-[ ] Configurable watched filetypes, either with a dotfile or flags
+[ ] Create a dotfile for configuration (as an alternative to command line arguments)
 
 [ ] Bug: halive crashes if multiple files are saved/added at once
 
@@ -73,6 +73,8 @@ DONE
     Once we've got this, we should be able to live edit Halive's source with Halive which should
     be a fun demo.
     (done thanks to Jonathan Geddes @jargv !)
+
+[x] Configurable watched filetypes (with flags)
 
 NOTES:
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Thanks to Chris Done's
 [`foreign-store`](https://hackage.haskell.org/package/foreign-store)
 library for enabling this.
 
+Watch custom file types for changes
+-----------------------------------
+
+By default, Halive will reload your code when files with the following extensions change: `hs`, `pd`, `frag`, `vert`.
+
+If you have any other file type that you'd like to be watched by Halive, use the `-f`/`--file-type` option.
+
+`halive app/Main.hs -f html -f hamlet`
+
 Passing command-line arguments
 ------------------------------
 

--- a/halive.cabal
+++ b/halive.cabal
@@ -11,7 +11,11 @@ description:
   .
   /Usage:/
   .
-  > halive path/to/myfile.hs [optionally any/extra include/dirs ..] -- [args to app]
+  > halive path/to/myfile.hs [optionally any/extra include/dirs ..] [-f|--file-type additional file type] -- [args to app]
+  .
+  Available options:
+  .
+  @-f, --file-type <file type>@ - Custom file type to watch for changes (e.g. @-f html@)
   .
   See <https://github.com/lukexi/halive/blob/master/README.md README>
 homepage:            https://github.com/lukexi/halive
@@ -33,6 +37,7 @@ library
   hs-source-dirs:      src
   exposed-modules:
     Halive
+    Halive.Args
     Halive.Utils
     Halive.Concurrent
     Halive.FindPackageDBs
@@ -93,6 +98,19 @@ executable halive
     , process
     , stm
     , halive
+
+
+test-suite unit
+  type: exitcode-stdio-1.0
+  default-language: Haskell2010
+  main-is: Spec.hs
+  hs-source-dirs: test/unit
+  other-modules:
+      Halive.ArgsSpec
+  build-depends:
+      base
+    , halive
+    , hspec
 
 test-suite demo
   type: exitcode-stdio-1.0

--- a/src/Halive/Args.hs
+++ b/src/Halive/Args.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Halive.Args
+    ( Args(..)
+    , FileType
+    , parseArgs
+    , usage) where
+
+type FileType = String
+
+data Args = Args
+    { mainFileName  :: String
+    , includeDirs   :: [String]
+    , fileTypes     :: [FileType]
+    , targetArgs    :: [String]
+    }
+
+data PartialArgs = PartialArgs
+    { mainFileName' :: Maybe String
+    , includeDirs'  :: [String]
+    , fileTypes'    :: [FileType]
+    , targetArgs'   :: [String]
+    }
+
+usage :: String
+usage = "Usage: halive <main.hs> [<include dir>] [-f|--file-type <file type>] [-- <args to myapp>]\n\
+        \\n\
+        \Available options:\n\
+        \  -f, --file-type <file type>     Custom file type to watch for changes (e.g. \"-f html\")"
+
+
+parseArgs :: [String] -> Maybe Args
+parseArgs args = go args (PartialArgs Nothing [] [] []) >>= fromPartial
+    where
+        go :: [String] -> PartialArgs -> Maybe PartialArgs
+        go [] partial = Just partial
+        go (x : xs) partial
+            | x == "--" = Just partial { targetArgs' = xs } 
+            | x == "-f" || x == "--file-type" =
+                case xs of
+                    []               -> Nothing
+                    ("--" : _)       -> Nothing
+                    (fileType : xs') -> go xs' $ partial { fileTypes' = fileType : fileTypes' partial }
+            | otherwise = 
+                case mainFileName' partial of
+                    Nothing -> go xs $ partial { mainFileName' = Just x }
+                    Just _  -> go xs $ partial { includeDirs' = x : includeDirs' partial}
+                    
+fromPartial :: PartialArgs -> Maybe Args
+fromPartial PartialArgs {..} = 
+    case mainFileName' of
+        Nothing -> Nothing
+        Just mfn -> Just Args 
+                            { mainFileName  = mfn
+                            , includeDirs   = includeDirs'
+                            , fileTypes     = fileTypes'
+                            , targetArgs    = targetArgs'
+                            }
+                

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,3 +2,6 @@ flags: {}
 packages:
 - '.'
 resolver: lts-8.2
+
+extra-deps:
+- gl-0.8.0

--- a/test/TestSubhalive.hs
+++ b/test/TestSubhalive.hs
@@ -17,8 +17,9 @@ main = do
              readTChan (recResultTChan barRecompiler))
         case result of
             Left errors -> putStrLn errors
-            Right value -> case getCompiledValue value of
-                Just value -> do
-                    putStrLn value
-                Nothing -> do
-                    putStrLn "Error: foo or bar was not of type String"
+            Right values -> forM_ values $ \value ->
+                case getCompiledValue value of
+                    Just v ->
+                        putStrLn v
+                    Nothing ->
+                        putStrLn "Error: foo or bar was not of type String"

--- a/test/unit/Halive/ArgsSpec.hs
+++ b/test/unit/Halive/ArgsSpec.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Halive.ArgsSpec where
+
+import Test.Hspec
+import Halive.Args
+import Data.Maybe
+import Data.Foldable
+
+deriving instance Show Args
+
+spec :: Spec
+spec = 
+    describe "Args.parseArgs" $ do
+
+        describe "mainfile" $ do
+            it "is required" $
+                forM_
+                    [ ""
+                    , "-f filetype"
+                    , "-f filetype -- targetArg"
+                    , "-- targetArg"
+                    ] $ \args -> parseArgs (words args) `shouldSatisfy` isNothing
+
+            it "can be parsed" $
+                case parseArgs (words "mainfile") of
+                    Just Args {..} -> mainFileName `shouldBe` "mainfile"
+
+        describe "include dirs" $ do
+            it "are optional" $
+                forM_
+                    [ "mainfile"
+                    , "mainfile -f filetype"
+                    , "mainfile -- targetArg"
+                    ] $ \args -> case parseArgs (words args) of
+                                    Just Args {..} -> includeDirs `shouldBe` []
+            
+            it "can be parsed" $
+                forM_ 
+                    [ "mainfile include1 include2"
+                    , "mainfile include1 -f filetype include2"
+                    , "mainfile include1 include2 -- targerArg"
+                    ] $ \args -> case parseArgs (words args) of
+                        Just Args {..} -> includeDirs `shouldMatchList` ["include1", "include2"]
+
+        describe "file types" $ do
+            it "are optional" $
+                case parseArgs (words "mainfile") of
+                    Just Args {..} -> fileTypes `shouldBe` []
+                    
+            it "can be specified in any position" $
+                case parseArgs (words "-f 1 mainfile -f 2 includedir -f 3") of
+                    Just Args {..} -> fileTypes `shouldMatchList` ["1", "2", "3"]
+
+            it "can be parsed using -f" $
+                case parseArgs (words "mainfile -f filetype") of
+                    Just Args {..} -> fileTypes `shouldBe` ["filetype"]
+
+            it "can be parsed using --file-type" $
+                case parseArgs (words "mainfile --file-type filetype") of
+                    Just Args {..} -> fileTypes `shouldBe` ["filetype"]
+
+            it "can't be parsed when flag is misused" $
+                forM_
+                    [ "mainfile -f"
+                    , "mainfile -f --"
+                    , "mainfile -f -- x"
+                    ] $ \args -> parseArgs (words args) `shouldSatisfy` isNothing
+
+        describe "target args" $ do
+            it "are optional" $
+                case parseArgs (words "mainfile") of
+                    Just Args {..} -> targetArgs `shouldBe` []
+
+            it "capture everything after `--`" $ 
+                case parseArgs (words "mainfile -- -f a b c") of
+                    Just Args {..} -> targetArgs `shouldBe` ["-f", "a", "b", "c"]

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -1,0 +1,2 @@
+-- preprocessor for discovering spec files
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
This PR adds a `-f`/`--file-type` option to allow users to ask Halive to watch custom file types for changes, as suggested in #11.

@lukexi's suggestion to add a configuration file was not addressed yet.

The changes to `stack.yaml` and `test\SubHalive.hs` were to fix the demo. It hasn't been in a compilable state since around [April 11](https://github.com/lukexi/halive/commit/751987e0091420a793b74477b0248d4fde4f0973), as far as I can tell.